### PR TITLE
Fixes false positive if previous platform command succeeded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+vendor/ruby

--- a/lib/kapost/bootstrapper.rb
+++ b/lib/kapost/bootstrapper.rb
@@ -63,6 +63,7 @@ module Kapost
     def check(command, help = nil, version: nil)
       say(label(command, version)) do
         begin
+          @platform_result = false
           result = block_given? ? yield : default_check(command, version)
           @platform_result || result
         rescue CommandError => ex

--- a/spec/kapost/bootstrapper_spec.rb
+++ b/spec/kapost/bootstrapper_spec.rb
@@ -98,12 +98,18 @@ describe Kapost::Bootstrapper do
           bootstrapper.instance_eval { check("test help", "Some help text") { false } }
         end
 
-        it "should print the help text after the label" do
-          expect(printer.output).to include "Some help text"
-        end
+        context "with previous platform success" do
+          before do
+            bootstrapper.instance_eval { check("test help", "Platform help text") { osx { true } } }
+          end
 
-        it "should exit" do
-          expect(shell).to have_received(:exit).with(1).at_least(:once)
+          it "should print the help text after the label" do
+            expect(printer.output).to include "Some help text"
+          end
+
+          it "should exit" do
+            expect(shell).to have_received(:exit).with(1).at_least(:once)
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+if ENV["CIRCLE_ARTIFACTS"]
+  require "simplecov"
+  dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
+  SimpleCov.coverage_dir(dir)
+  SimpleCov.start "rails"
+end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'kapost/bootstrapper'


### PR DESCRIPTION
If you called a platform command that succeeded, that success would occlude future failures that do not use platform commands.

@paul 