### PR TITLE
[bugfix] fixes error thrown when ruby version mismatches

### DIFF
--- a/lib/kapost/bootstrapper.rb
+++ b/lib/kapost/bootstrapper.rb
@@ -56,7 +56,7 @@ module Kapost
     def default_check(command, version)
       installed?(command) or raise CommandNotFoundError, command
       if version
-        actual_version = right_version?(command, version) or raise CommandVersionMismatchError, command, version, actual_version
+        actual_version = right_version?(command, version) or raise CommandVersionMismatchError.new(command, version, actual_version)
       end
       true
     end

--- a/lib/kapost/bootstrapper/version.rb
+++ b/lib/kapost/bootstrapper/version.rb
@@ -1,5 +1,5 @@
 module Kapost
   class Bootstrapper
-    VERSION = "1.0.5"
+    VERSION = "1.0.6"
   end
 end

--- a/spec/kapost/bootstrapper_spec.rb
+++ b/spec/kapost/bootstrapper_spec.rb
@@ -418,7 +418,11 @@ describe Kapost::Bootstrapper do
       it "returns false" do
         expect(bootstrapper.right_version?("ruby", dot_ruby_version)).to equal(false)
       end
+      it "throws an error" do
+        required_ruby_version = '1000.1'
+        bootstrapper.check "ruby", "version help text", version: required_ruby_version
+        expect(printer.output).to include('incorrect version')
+      end
     end
   end
-
 end


### PR DESCRIPTION
This was failing because according to the [ruby
docs](https://ruby-doc.org/core-2.3.1/Kernel.html#method-i-raise) raise expects the arguments as Exception, String (message), Array of Callback Information. This caused our current code to throw an argument mistmatch error. 

Alternatively raise can be given an instantiated error which is how I was able
to achieve the intended functionality.