### PR TITLE
SemVer handling for right_check? method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :development, :test do
   gem "guard-rspec"
 
   gem "codeclimate-test-reporter", require: nil
+  gem "semantic"
 end

--- a/lib/kapost/bootstrapper.rb
+++ b/lib/kapost/bootstrapper.rb
@@ -91,8 +91,17 @@ module Kapost
 
     def right_version?(command, expected_version)
       version, status = cli.capture2e "#{command} --version"
-      status.success? && version.include?(expected_version) && version
+      if expected_version[0] == '^'
+        next_major = (expected_version[1].to_i + 1).to_s
+        Gem::Version.new(version) >= Gem::Version.new(expected_version[1..-1]) && Gem::Version.new(version) < Gem::Version.new(next_major)
+      elsif expected_version[0] == "="
+        Gem::Version.new(version) == Gem::Version.new(expected_version[1..-1])
+      else
+        local_version = Semantic::Version.new(version)
+        local_version.satisfies?(expected_version)
+      end
     end
+
 
     def say(message)
       if block_given?

--- a/lib/kapost/bootstrapper/version.rb
+++ b/lib/kapost/bootstrapper/version.rb
@@ -1,5 +1,5 @@
 module Kapost
   class Bootstrapper
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end

--- a/spec/kapost/bootstrapper_spec.rb
+++ b/spec/kapost/bootstrapper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'semantic'
 
 describe Kapost::Bootstrapper do
 
@@ -176,6 +177,197 @@ describe Kapost::Bootstrapper do
 
           it "should not print the success marker" do
             expect(printer.output).to_not include("✓")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#right_version?" do
+
+    context "caret ranges" do
+      before do
+        allow(cli).to receive(:capture2e).and_return(["7.1.2", success])
+      end
+
+      context "when local node/yarn/npm is a major version above package.json" do
+        let(:packagejson_version) {"^6.11.3"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node/yarn/npm version is less than package.json" do
+        let(:packagejson_version) {"^7.1.3"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node/yarn/npm is equal to package.json" do
+        let(:packagejson_version) {"^7.1.2"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+    end
+
+    context "> comparator" do
+      before do
+        allow(cli).to receive(:capture2e).and_return(["6.11.2", success])
+      end
+
+      context "when local node/yarn/npm is greater than package.json" do
+        let(:packagejson_version) {">6.11.1"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+
+      context "when local node/yarn/npm is equal to package.json" do
+        let(:packagejson_version) {">6.11.2"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node/yarn/npm is less than package.json" do
+        let(:packagejson_version) {">6.11.3"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+    end
+
+    context ">= comparator" do
+      before do
+        allow(cli).to receive(:capture2e).and_return(["6.11.2", success])
+      end
+
+      context "when local node/yarn/npm is greater than package.json" do
+        let(:packagejson_version) {">=6.11.1"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+
+      context "when local node/yarn/npm is less than package.json" do
+        let(:packagejson_version) {">=6.11.3"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node/yarn/npm is equal to package.json" do
+        let(:packagejson_version) {">=6.11.2"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+    end
+
+    context "< comparator" do
+      before do
+        allow(cli).to receive(:capture2e).and_return(["6.11.1", success])
+      end
+
+      context "when local node/yarn/npm is less than package.json" do
+        let(:packagejson_version) {"<6.11.4"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+
+      context "when local node/yarn/npm is greater than package.json" do
+        let(:packagejson_version) {"<6.11.0"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node/yarn/npm is equal to package.json" do
+        let(:packagejson_version) {"<6.11.1"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+    end
+
+    context "<= comparator" do
+      before do
+        allow(cli).to receive(:capture2e).and_return(["6.11.3", success])
+      end
+
+      context "when local node/yarn/npm is greater than package.json" do
+        let(:packagejson_version) {"<=6.11.2"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node/yarn/npm is less than package.json" do
+        let(:packagejson_version) {"<=6.11.4"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+
+      context "when local node/yarn/npm is equal to package.json" do
+        let(:packagejson_version) {"<=6.11.3"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+    end
+
+    context "= or \"\" comparators" do
+      before do
+        allow(cli).to receive(:capture2e).and_return(["6.11.3", success])
+      end
+
+      context "= comparator" do
+
+        context "when local node/yarn/npm is less than package.json" do
+          let(:packagejson_version) {"=6.11.2"}
+          it "returns false" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+          end
+        end
+
+        context "when local node/yarn/npm is greater than package.json" do
+          let(:packagejson_version) {"=6.11.4"}
+          it "returns false" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+          end
+        end
+
+        context "when local node/yarn/npm is equal to package.json" do
+          let(:packagejson_version) {"=6.11.3"}
+          it "returns true" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+          end
+        end
+      end
+
+      context "no comparator" do
+        context "when local node/yarn/npm is less than package.json" do
+          let(:packagejson_version) {"6.11.2"}
+          it "returns false" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+          end
+        end
+
+        context "when local node/yarn/npm is greater than package.json" do
+          let(:packagejson_version) {"6.11.4"}
+          it "returns false" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+          end
+        end
+
+        context "when local node/yarn/npm is equal to package.json" do
+          let(:packagejson_version) {"6.11.3"}
+          it "returns true" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
           end
         end
       end


### PR DESCRIPTION
See: https://kapost.atlassian.net/browse/DEVOPS-985

This PR add semantic versioning support to the `right_check?` method. In the past, this was a 1:1 match only, which was frustrating when typically semantic versioning comparators are used for packages such as node, yarn, and npm in `package.json`.

__Disclaimer__: This is my first time wrangling with ruby, so please be gentle

Open to suggestions on changes that will improve readability / execution.