### PR TITLE
more version handling

### DIFF
--- a/kapost-bootstrapper.gemspec
+++ b/kapost-bootstrapper.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "semantic" "~>1.6"
+  spec.add_development_dependency "semantic", "~>1.6"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/kapost-bootstrapper.gemspec
+++ b/kapost-bootstrapper.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "semantic" "~>1.6"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/kapost/bootstrapper.rb
+++ b/lib/kapost/bootstrapper.rb
@@ -91,20 +91,27 @@ module Kapost
     end
 
     def right_version?(command, expected_version)
-      version, status = cli.capture2e "#{command} --version"
-      if version[0] == 'v'
-        version = version[1..-1]
-      end
-      if expected_version[0] == '^'
+      version, status = get_version(command)
+      if expected_version[0] == "^"
         next_major = (expected_version[1].to_i + 1).to_s
         Gem::Version.new(version) >= Gem::Version.new(expected_version[1..-1]) && Gem::Version.new(version) < Gem::Version.new(next_major)
       elsif expected_version[0] == "="
         Gem::Version.new(version) == Gem::Version.new(expected_version[1..-1])
-      elsif version.include?("ruby")
-        status.success? && version.include?(expected_version)
       else
         local_version = Semantic::Version.new(version)
         local_version.satisfies?(expected_version)
+      end
+    end
+
+    def get_version(command)
+      version, status = cli.capture2e "#{command} --version"
+      if version[0] == "v"
+        version = version[1..-1]
+      elsif version.include?("ruby")
+        version.slice! "ruby "
+        version = version[0..4]
+      else
+        version
       end
     end
 

--- a/lib/kapost/bootstrapper.rb
+++ b/lib/kapost/bootstrapper.rb
@@ -92,17 +92,21 @@ module Kapost
 
     def right_version?(command, expected_version)
       version, status = cli.capture2e "#{command} --version"
+      if version[0] == 'v'
+        version = version[1..-1]
+      end
       if expected_version[0] == '^'
         next_major = (expected_version[1].to_i + 1).to_s
         Gem::Version.new(version) >= Gem::Version.new(expected_version[1..-1]) && Gem::Version.new(version) < Gem::Version.new(next_major)
       elsif expected_version[0] == "="
         Gem::Version.new(version) == Gem::Version.new(expected_version[1..-1])
+      elsif version.include?("ruby")
+        status.success? && version.include?(expected_version)
       else
         local_version = Semantic::Version.new(version)
         local_version.satisfies?(expected_version)
       end
     end
-
 
     def say(message)
       if block_given?

--- a/lib/kapost/bootstrapper/version.rb
+++ b/lib/kapost/bootstrapper/version.rb
@@ -1,5 +1,5 @@
 module Kapost
   class Bootstrapper
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end

--- a/spec/kapost/bootstrapper_spec.rb
+++ b/spec/kapost/bootstrapper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'semantic'
 
 describe Kapost::Bootstrapper do
 
@@ -372,6 +373,53 @@ describe Kapost::Bootstrapper do
       end
     end
 
+    context "node version specific - handling 'v' " do
+      before do
+        allow(cli).to receive(:capture2e).and_return(["v6.11.3", success])
+      end
+
+      context "when local node is less than package.json" do
+        let(:packagejson_version) {"6.11.4"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node is greater than package.json" do
+        let(:packagejson_version) {"6.11.2"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
+      context "when local node is greater than package.json" do
+        let(:packagejson_version) {"6.11.3"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+    end
+
+  end
+
+  context "ruby version" do
+    before do
+      allow(cli).to receive(:capture2e).and_return(["ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin16]", success])
+    end
+
+    context "ruby version includes the expected version" do
+      let(:dot_ruby_version) {"2.3.1"}
+      it "returns true" do
+        expect(bootstrapper.right_version?("ruby", dot_ruby_version)).to equal(true)
+      end
+    end
+
+    context "ruby version is not included in expected version" do
+      let(:dot_ruby_version) {"2.4.1"}
+      it "returns false" do
+        expect(bootstrapper.right_version?("ruby", dot_ruby_version)).to equal(false)
+      end
+    end
   end
 
 end

--- a/spec/kapost/bootstrapper_spec.rb
+++ b/spec/kapost/bootstrapper_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'semantic'
 
 describe Kapost::Bootstrapper do
 


### PR DESCRIPTION
Too many assumptions were made when I originally PR'd this functionality.  

1. node versions are preceded with `v` when running `node --version` (ex: `v6.11.1`)
2. The logic that was replaced when adding semantic versioning handled `ruby --version`. 

Changes to the `right_version?` block resolve these over-looked assumptions with supported tests.

**Changes on the app side:**
Some changes will need to be made `bin/bootstrap` at the app repo level. 

1. translates need to be removed from node and yarn version variables since `kapost-bootstrapper` can now handle semver. 
Ex: node_version = PACKAGE_JSON["engines"]["node"]~.tr("^", "")~

2. Either explicitly add `semantic` to Gemfile, or install via `bin/setup` (like `kapost-bootstrapper`)
```
#!/usr/bin/env bash

set -euvxo pipefail

gem which kapost-bootstrapper || gem install kapost-bootstrapper
gem which semantic || gem install semantic

./bin/bootstrap
``` 

Are there any other "gotchas" you can think of? Looking through the popular apps' `bin/bootstrap` files, it seems that the `right_version?` method is only used for ruby, node, npm, and yarn. 

