### PR TITLE
Gemfile fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0.5
+
+* Fixed an issue where `semantic` wasn't being installed as a dependency when `kapost-bootstrapper` is used in other apps.

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,3 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in kapost-bootstrapper.gemspec
 gemspec
-
-group :development, :test do
-  gem "guard"
-  gem "guard-rspec"
-
-  gem "codeclimate-test-reporter", require: nil
-  gem "semantic"
-end

--- a/kapost-bootstrapper.gemspec
+++ b/kapost-bootstrapper.gemspec
@@ -6,8 +6,8 @@ require 'kapost/bootstrapper/version'
 Gem::Specification.new do |spec|
   spec.name          = "kapost-bootstrapper"
   spec.version       = Kapost::Bootstrapper::VERSION
-  spec.authors       = ["Paul Sadauskas"]
-  spec.email         = ["paul@sadauskas.com"]
+  spec.authors       = ["Kapost Engineering"]
+  spec.email         = ["engineering@kapost.com"]
 
   spec.summary       = %q{A small helper utility for your app to declare and setup its system dependencies}
   spec.homepage      = "https://github.com/kapost/kapost-bootstrapper"
@@ -17,8 +17,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "semantic", "~>1.6"
+  spec.add_dependency "semantic", "~> 1.6"
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "guard", "~> 2.14"
+  spec.add_development_dependency "guard-rspec", "~> 4.7"
+  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0"
 end

--- a/lib/kapost/bootstrapper/version.rb
+++ b/lib/kapost/bootstrapper/version.rb
@@ -1,5 +1,5 @@
 module Kapost
   class Bootstrapper
-    VERSION = "1.0.4"
+    VERSION = "1.0.5"
   end
 end


### PR DESCRIPTION
Main change is to move `semantic` out of dev dependencies.  Also added a `CHANGELOG.md` so we can more easily understand whats changing over time.