### PR TITLE
circle2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/kapost-bootstrapper
+    docker:
+      - image: circleci/ruby:2.5.0
+    steps:
+      - checkout
+      - run: gem install bundler
+      - run: bundle install
+      - run:
+          name: Rspec
+          command: bundle exec rspec --format documentation --color spec

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-dependencies:
-  pre:
-    - gem install bundler


### PR DESCRIPTION
Circle is [sunsetting](https://circleci.com/blog/sunsetting-1-0/) 1.0 on August 31, 2018.

DevOps is going through all remaining 1.0 apps and converting them now so we can tackle any issues now before the impending date.

Most of these will be really easy like this one 🤞 