### PR TITLE
Properly handle two digit caret ranges version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.7
+
+* Fixed an issue where the caret range version (e.g. `^12.16.1`) didn't handle more than a single digit for the major version check.
+
 ## v1.0.5
 
 * Fixed an issue where `semantic` wasn't being installed as a dependency when `kapost-bootstrapper` is used in other apps.

--- a/lib/kapost/bootstrapper.rb
+++ b/lib/kapost/bootstrapper.rb
@@ -93,7 +93,8 @@ module Kapost
     def right_version?(command, expected_version)
       version, status = get_version(command)
       if expected_version[0] == "^"
-        next_major = (expected_version[1].to_i + 1).to_s
+        # Parse out the major version and add 1. "^12.16.1" => 13
+        next_major = (expected_version[1..-1].split(".").first.to_i + 1).to_s
         Gem::Version.new(version) >= Gem::Version.new(expected_version[1..-1]) && Gem::Version.new(version) < Gem::Version.new(next_major)
       elsif expected_version[0] == "="
         Gem::Version.new(version) == Gem::Version.new(expected_version[1..-1])

--- a/lib/kapost/bootstrapper/version.rb
+++ b/lib/kapost/bootstrapper/version.rb
@@ -1,5 +1,5 @@
 module Kapost
   class Bootstrapper
-    VERSION = "1.0.6"
+    VERSION = "1.0.7"
   end
 end

--- a/spec/kapost/bootstrapper_spec.rb
+++ b/spec/kapost/bootstrapper_spec.rb
@@ -196,6 +196,20 @@ describe Kapost::Bootstrapper do
         end
       end
 
+      context "when local node/yarn/npm is at a compatible major and minor version for package.json" do
+        let(:packagejson_version) {"^7.1.1"}
+        it "returns true" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+
+      context "when local node/yarn/npm is at a incompatible minor version for package.json" do
+        let(:packagejson_version) {"^7.2.1"}
+        it "returns false" do
+          expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+        end
+      end
+
       context "when local node/yarn/npm version is less than package.json" do
         let(:packagejson_version) {"^7.1.3"}
         it "returns false" do
@@ -207,6 +221,33 @@ describe Kapost::Bootstrapper do
         let(:packagejson_version) {"^7.1.2"}
         it "returns true" do
           expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+        end
+      end
+
+      context "double digit major version" do
+        before do
+          allow(cli).to receive(:capture2e).and_return(["12.16.2", success])
+        end
+
+        context "when local node/yarn/npm is a major version above package.json" do
+          let(:packagejson_version) {"^13.11.3"}
+          it "returns false" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+          end
+        end
+
+        context "when local node/yarn/npm is at a compatible major and minor for package.json" do
+          let(:packagejson_version) {"^12.16.1"}
+          it "returns true" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(true)
+          end
+        end
+
+        context "when local node/yarn/npm is a minor version below package.json" do
+          let(:packagejson_version) {"^12.17.3"}
+          it "returns false" do
+            expect(bootstrapper.right_version?("node", packagejson_version)).to equal(false)
+          end
         end
       end
     end


### PR DESCRIPTION
### Overview
- `^12.16.1` version checks were failing because the code
  could only handle single digit major versions.

### Screencast
Working in watercress. I will also tweak watercress but the main check is working.
![2020-04-23_11-32-27 (1)](https://user-images.githubusercontent.com/1525033/80130793-6536e700-8556-11ea-9f94-46124d582ad2.gif)
